### PR TITLE
Fix `conf_only` logic for nvimlua

### DIFF
--- a/lua/coq_3p/nvimlua/init.lua
+++ b/lua/coq_3p/nvimlua/init.lua
@@ -1,5 +1,10 @@
 return function(spec)
-  local conf_only = spec.conf_only ~= nil and spec.conf_only or true
+  local conf_only = true
+
+  if spec.conf_only ~= nil then
+    conf_only = spec.conf_only
+  end
+
   vim.validate {
     conf_only = {conf_only, "boolean"}
   }


### PR DESCRIPTION
The existing logic was always evaluating to `true`, making it impossible
to use nvimlua completion for nvim configuration files outside of
`~/.config/`. This is problematic when using something like `rcup` or
`stow` to manage dotfiles.