### PR TITLE
cow,figlet: fix unintended nil return

### DIFF
--- a/lua/coq_3p/cow/init.lua
+++ b/lua/coq_3p/cow/init.lua
@@ -44,8 +44,8 @@ return function(spec)
         }
       )
 
-      return acc
     end
+    return acc
   end)()
 
   local styles = {"-b", "-d", "-g", "-p", "-s", "-t", "-w", "-y"}

--- a/lua/coq_3p/figlet/init.lua
+++ b/lua/coq_3p/figlet/init.lua
@@ -45,8 +45,8 @@ return function(spec)
         }
       )
 
-      return acc
     end
+    return acc
   end)()
 
   local locked = false


### PR DESCRIPTION
Currently if cowsay/figlet aren't in the path, the lambdas for cows/fonts return nil and the scripts error out with:

    [...]/coq.thirdparty/lua/coq_3p/cow/init.lua:64: attempt to get length of upvalue 'cows' (a nil value)
    [...]/coq.thirdparty/lua/coq_3p/figlet/init.lua:64: attempt to get length of upvalue 'fonts' (a nil value)

This PR simply moves the return statement out of the `if #cow_path` / `if #fig_path` blocks.