### PR TITLE
fix(dap): omnifunc deprecate warning

### DIFF
--- a/lua/coq_3p/dap/init.lua
+++ b/lua/coq_3p/dap/init.lua
@@ -1,5 +1,5 @@
 return function(spec)
-  _G.coq_3p_dap_omnifunc = require("dap").omnifunc
+  _G.coq_3p_dap_omnifunc = require("dap.repl").omnifunc
   return require("coq_3p.omnifunc") {
     use_cache = true,
     omnifunc = "v:lua.coq_3p_dap_omnifunc",


### PR DESCRIPTION
dap.omnifunc is deprecated. Use require('dap.repl').omnifunc instead.
