### PR TITLE
Allow for specifing fonts to figlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ requires - [`cowsay`](https://linux.die.net/man/1/cowsay)
 `{ src = "figlet", short_name = "BIG" }`
 
 Use **`trigger = "!big"`** to only show figlet when you end a line with `!big`
+
 Use **`fonts = {"/usr/share/figlet/fonts/standard.flf"}`** specify the list of fonts to choose from
 
 ![figlet.img](https://raw.githubusercontent.com/ms-jpq/coq.artifacts/artifacts/preview/figlet.gif)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ requires - [`cowsay`](https://linux.die.net/man/1/cowsay)
 `{ src = "figlet", short_name = "BIG" }`
 
 Use **`trigger = "!big"`** to only show figlet when you end a line with `!big`
+Use **`fonts = {"/usr/share/figlet/fonts/standard.flf"}`** specify the list of fonts to choose from
 
 ![figlet.img](https://raw.githubusercontent.com/ms-jpq/coq.artifacts/artifacts/preview/figlet.gif)
 

--- a/lua/coq_3p/figlet/init.lua
+++ b/lua/coq_3p/figlet/init.lua
@@ -2,52 +2,58 @@ local utils = require("coq_3p.utils")
 
 return function(spec)
   local trigger = spec.trigger
-  vim.validate {trigger = {trigger, "string", true}}
+  local font_spec = spec.font
+  vim.validate {trigger = {trigger, "string", true}, font_spec = {font_spec, "string", true}}
 
   local fig_path = vim.fn.exepath("figlet")
 
-  local fonts =
-    (function()
-    local acc = {}
+  local fonts = nil
+  if font_spec == nil then
+    fonts =
+      (function()
+      local acc = {}
 
-    if #fig_path > 0 then
-      local stdout = nil
+      if #fig_path > 0 then
+        local stdout = nil
 
-      local fin = function()
-        local fonts_dir = table.concat(stdout, "")
-        vim.fn.readdir(
-          fonts_dir,
-          function(name)
-            if vim.endswith(name, ".flf") then
-              local font = fonts_dir .. "/" .. name
-              table.insert(acc, font)
+        local fin = function()
+          local fonts_dir = table.concat(stdout, "")
+          vim.fn.readdir(
+            fonts_dir,
+            function(name)
+              if vim.endswith(name, ".flf") then
+                local font = fonts_dir .. "/" .. name
+                table.insert(acc, font)
+              end
             end
-          end
+          )
+        end
+
+        vim.fn.jobstart(
+          {fig_path, "-I", "2"},
+          {
+            stderr_buffered = true,
+            stdout_buffered = true,
+            on_exit = function(_, code)
+              if code == 0 and stdout then
+                fin()
+              end
+            end,
+            on_stderr = function(_, lines)
+              utils.debug_err(unpack(lines))
+            end,
+            on_stdout = function(_, lines)
+              stdout = lines
+            end
+          }
         )
+
+        return acc
       end
-
-      vim.fn.jobstart(
-        {fig_path, "-I", "2"},
-        {
-          stderr_buffered = true,
-          stdout_buffered = true,
-          on_exit = function(_, code)
-            if code == 0 and stdout then
-              fin()
-            end
-          end,
-          on_stderr = function(_, lines)
-            utils.debug_err(unpack(lines))
-          end,
-          on_stdout = function(_, lines)
-            stdout = lines
-          end
-        }
-      )
-
-      return acc
-    end
-  end)()
+    end)()
+  else
+    fonts = (function() return {font_spec}end)()
+  end
 
   local locked = false
   return function(args, callback)

--- a/lua/coq_3p/figlet/init.lua
+++ b/lua/coq_3p/figlet/init.lua
@@ -2,8 +2,8 @@ local utils = require("coq_3p.utils")
 
 return function(spec)
   local trigger = spec.trigger
-  local font_spec = spec.font
-  vim.validate {trigger = {trigger, "string", true}, font_spec = {font_spec, "string", true}}
+  local font_spec = spec.fonts
+  vim.validate {trigger = {trigger, "string", true}, font_spec = {font_spec, "table", true}}
 
   local fig_path = vim.fn.exepath("figlet")
 
@@ -52,7 +52,7 @@ return function(spec)
       end
     end)()
   else
-    fonts = (function() return {font_spec}end)()
+    fonts = (function() return font_spec end)()
   end
 
   local locked = false


### PR DESCRIPTION
Currently the figlet source picks a random font from the font directory.
I don't like this as personally like all my banners to have the same font.
These changes add a config option to specify a table of fonts to pick from.