### PR TITLE
Add mysql filetype to vim_dadbod_completion

### DIFF
--- a/lua/coq_3p/vim_dadbod_completion/init.lua
+++ b/lua/coq_3p/vim_dadbod_completion/init.lua
@@ -2,6 +2,6 @@ return function(spec)
   return require("coq_3p.omnifunc") {
     use_cache = true,
     omnifunc = "vim_dadbod_completion#omni",
-    filetypes = {"sql", "psql"}
+    filetypes = {"mysql", "sql", "psql"}
   }
 end


### PR DESCRIPTION
MySQL filetype autocompletion isn't supported by default. This just adds that.