### PR TITLE
Nvim 0.13 deprecation fix and nit

### DIFF
--- a/lua/coq_3p/init.lua
+++ b/lua/coq_3p/init.lua
@@ -5,7 +5,7 @@ local utils = require("coq_3p.utils")
 ---@field public short_name string | nil
 
 ---@param sources Source[]
-return function(sources)
+local function setup(sources)
   COQsources = COQsources or {}
   utils.validate {
     COQsources = {COQsources, "table"},
@@ -53,3 +53,5 @@ return function(sources)
     end
   end
 end
+
+return setmetatable({ setup = setup }, { __call = function(_, ...) setup(...) end })

--- a/lua/coq_3p/repl/unsafe.lua
+++ b/lua/coq_3p/repl/unsafe.lua
@@ -99,4 +99,4 @@ local misc = {
   "yes"
 }
 
-return vim.tbl_flatten {init, exec, sys, fs, mkfs, misc}
+return vim.iter{init, exec, sys, fs, mkfs, misc}:flatten():totable()


### PR DESCRIPTION
Fixes the nvim 0.13 deprecation warning

<img width="898" height="179" alt="image" src="https://github.com/user-attachments/assets/d71e20e0-e598-4fc4-b108-4cb266f15ef6" />
